### PR TITLE
Generate SAS token for every request

### DIFF
--- a/src/DependencyInjection/AymDevMessengerAzureExtension.php
+++ b/src/DependencyInjection/AymDevMessengerAzureExtension.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace AymDev\MessengerAzureBundle\DependencyInjection;
 
 use AymDev\MessengerAzureBundle\Messenger\Transport\AzureHttpClientConfigurationBuilder;
+use AymDev\MessengerAzureBundle\Messenger\Transport\AzureHttpClientFactory;
 use AymDev\MessengerAzureBundle\Messenger\Transport\AzureTransportFactory;
+use AymDev\MessengerAzureBundle\Messenger\Transport\DsnParser;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -24,6 +26,14 @@ final class AymDevMessengerAzureExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
+        // DSN parser
+        $dsnParserId = self::SERVICE_PREFIX . '.dsn_parser';
+        $dsnParserDefinition = new Definition(DsnParser::class);
+        $container
+            ->setDefinition($dsnParserId, $dsnParserDefinition)
+            ->setPublic(false)
+        ;
+
         // HttpClient configuration builder
         $httpConfigBuilderId = self::SERVICE_PREFIX . '.http_config_builder';
         $httpConfigBuilderDefinition = new Definition(AzureHttpClientConfigurationBuilder::class);
@@ -32,10 +42,20 @@ final class AymDevMessengerAzureExtension extends Extension
             ->setPublic(false)
         ;
 
+        // HttpClient factory
+        $httpClientFactoryId = self::SERVICE_PREFIX . '.http_client_factory';
+        $httpClientFactoryDefinition = new Definition(AzureHttpClientFactory::class);
+        $container
+            ->setDefinition($httpClientFactoryId, $httpClientFactoryDefinition)
+            ->setPublic(false)
+        ;
+
         // Transport factory
         $container
             ->setDefinition(self::SERVICE_PREFIX . '.transport_factory', new Definition(AzureTransportFactory::class))
+            ->addArgument(new Reference($dsnParserId))
             ->addArgument(new Reference($httpConfigBuilderId))
+            ->addArgument(new Reference($httpClientFactoryId))
             ->addTag('messenger.transport_factory')
             ->setPublic(false)
         ;

--- a/src/Messenger/Transport/AzureHttpClient.php
+++ b/src/Messenger/Transport/AzureHttpClient.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AymDev\MessengerAzureBundle\Messenger\Transport;
+
+use Symfony\Component\HttpClient\DecoratorTrait;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class AzureHttpClient implements HttpClientInterface
+{
+    use DecoratorTrait;
+
+    /** @var SasTokenGenerator */
+    private $sasTokenGenerator;
+
+    public function __construct(HttpClientInterface $client, SasTokenGenerator $sasTokenGenerator)
+    {
+        $this->client = $client;
+        $this->sasTokenGenerator = $sasTokenGenerator;
+    }
+
+    /**
+     * @param mixed[] $options
+     */
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        /** @var array{headers?: array<string, string>} $options */
+        $options['headers'] = $options['headers'] ?? [];
+        $options['headers']['Authorization'] = $this->sasTokenGenerator->generateSharedAccessSignatureToken();
+
+        return $this->client->request($method, $url, $options);
+    }
+}

--- a/src/Messenger/Transport/AzureHttpClientFactory.php
+++ b/src/Messenger/Transport/AzureHttpClientFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AymDev\MessengerAzureBundle\Messenger\Transport;
+
+use Symfony\Component\HttpClient\HttpClient;
+
+class AzureHttpClientFactory
+{
+    /**
+     * @param array{
+     *     endpoint: string,
+     *     shared_access_key_name: string,
+     *     shared_access_key: string,
+     *     token_expiry: int,
+     *     options: mixed[]
+     * } $options
+     * @return AzureHttpClient
+     */
+    public function createClient(array $options): AzureHttpClient
+    {
+        $httpClient = HttpClient::createForBaseUri(
+            $options['endpoint'],
+            $options['options'],
+        );
+
+        $sasTokenGenerator = new SasTokenGenerator(
+            $options['endpoint'],
+            $options['shared_access_key_name'],
+            $options['shared_access_key'],
+            $options['token_expiry']
+        );
+
+        return new AzureHttpClient($httpClient, $sasTokenGenerator);
+    }
+}

--- a/src/Messenger/Transport/DsnParser.php
+++ b/src/Messenger/Transport/DsnParser.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AymDev\MessengerAzureBundle\Messenger\Transport;
+
+class DsnParser
+{
+    /**
+     * Parse the DSN to extract the namespace and shared access key
+     * @return array{
+     *     shared_access_key_name: string,
+     *     shared_access_key: string,
+     *     namespace: string,
+     * }
+     */
+    public function parseDsn(string $dsn, string $transportName): array
+    {
+        if (1 !== preg_match('~^azure://(.+):(.+)@(.+)$~', $dsn, $matches)) {
+            $message = sprintf('Invalid Azure Service Bus DSN for the "%s" transport. ', $transportName);
+            $message .= 'It must be in the following format: azure://SharedAccessKeyName:SharedAccessKey@namespace';
+            throw new \InvalidArgumentException($message, 1643988474);
+        }
+
+        return [
+            'shared_access_key_name' => $matches[1],
+            'shared_access_key' => $matches[2],
+            'namespace' => $matches[3],
+        ];
+    }
+}

--- a/src/Messenger/Transport/SasTokenGenerator.php
+++ b/src/Messenger/Transport/SasTokenGenerator.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AymDev\MessengerAzureBundle\Messenger\Transport;
+
+class SasTokenGenerator
+{
+    /** @var string */
+    private $endpoint;
+
+    /** @var string */
+    private $accessKeyName;
+
+    /** @var string */
+    private $accessKey;
+
+    /** @var int */
+    private $tokenExpiry;
+
+    public function __construct(string $endpoint, string $accessKeyName, string $accessKey, int $tokenExpiry)
+    {
+        $this->endpoint = $endpoint;
+        $this->accessKeyName = $accessKeyName;
+        $this->accessKey = $accessKey;
+        $this->tokenExpiry = $tokenExpiry;
+    }
+
+    /**
+     * Generate the SAS token used to authenticate on Azure Service Bus REST API.
+     */
+    public function generateSharedAccessSignatureToken(): string
+    {
+        // Token expiry instant
+        $expiry = time() + $this->tokenExpiry;
+
+        // URL-encoded URI of the resource being accessed
+        $resource = strtolower(rawurlencode(strtolower($this->endpoint)));
+
+        // URL-encoded HMAC SHA256 signature
+        $toSign = $resource . "\n" . $expiry;
+        $signature = rawurlencode(base64_encode(hash_hmac('sha256', $toSign, $this->accessKey, true)));
+
+        return sprintf(
+            'SharedAccessSignature sig=%s&se=%d&skn=%s&sr=%s',
+            $signature,
+            $expiry,
+            $this->accessKeyName,
+            $resource
+        );
+    }
+}

--- a/tests/Messenger/Transport/AzureTransportFactoryTest.php
+++ b/tests/Messenger/Transport/AzureTransportFactoryTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Tests\AymDev\MessengerAzureBundle\Messenger\Transport;
 
 use AymDev\MessengerAzureBundle\Messenger\Transport\AzureHttpClientConfigurationBuilder;
+use AymDev\MessengerAzureBundle\Messenger\Transport\AzureHttpClientFactory;
 use AymDev\MessengerAzureBundle\Messenger\Transport\AzureTransport;
 use AymDev\MessengerAzureBundle\Messenger\Transport\AzureTransportFactory;
+use AymDev\MessengerAzureBundle\Messenger\Transport\DsnParser;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
@@ -17,7 +19,11 @@ final class AzureTransportFactoryTest extends TestCase
      */
     public function testSupportsAzureDsn(): void
     {
-        $factory = new AzureTransportFactory(new AzureHttpClientConfigurationBuilder());
+        $factory = new AzureTransportFactory(
+            new DsnParser(),
+            new AzureHttpClientConfigurationBuilder(),
+            new AzureHttpClientFactory()
+        );
 
         self::assertTrue($factory->supports('azure://KeyName:Key@namespace', []));
         self::assertTrue($factory->supports('azure://', []));
@@ -32,7 +38,11 @@ final class AzureTransportFactoryTest extends TestCase
         self::expectException(\InvalidArgumentException::class);
         self::expectExceptionCode(1643989596);
 
-        $factory = new AzureTransportFactory(new AzureHttpClientConfigurationBuilder());
+        $factory = new AzureTransportFactory(
+            new DsnParser(),
+            new AzureHttpClientConfigurationBuilder(),
+            new AzureHttpClientFactory()
+        );
 
         $factory->createTransport(
             'azure://KeyName:Key@namespace',
@@ -51,7 +61,11 @@ final class AzureTransportFactoryTest extends TestCase
         self::expectException(\InvalidArgumentException::class);
         self::expectExceptionCode(1643994036);
 
-        $factory = new AzureTransportFactory(new AzureHttpClientConfigurationBuilder());
+        $factory = new AzureTransportFactory(
+            new DsnParser(),
+            new AzureHttpClientConfigurationBuilder(),
+            new AzureHttpClientFactory()
+        );
 
         $factory->createTransport(
             'azure://KeyName:Key@namespace',
@@ -69,7 +83,11 @@ final class AzureTransportFactoryTest extends TestCase
      */
     public function testCreateTransport(): void
     {
-        $factory = new AzureTransportFactory(new AzureHttpClientConfigurationBuilder());
+        $factory = new AzureTransportFactory(
+            new DsnParser(),
+            new AzureHttpClientConfigurationBuilder(),
+            new AzureHttpClientFactory()
+        );
 
         $transport = $factory->createTransport(
             'azure://KeyName:Key@namespace',

--- a/tests/Messenger/Transport/DsnParserTest.php
+++ b/tests/Messenger/Transport/DsnParserTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Messenger\Transport;
+
+use AymDev\MessengerAzureBundle\Messenger\Transport\DsnParser;
+use PHPUnit\Framework\TestCase;
+
+class DsnParserTest extends TestCase
+{
+    public function testParseValidDsn(): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parseDsn('azure://key-name:key-value@namespace-name', 'my-transport');
+
+        self::assertSame([
+            'shared_access_key_name' => 'key-name',
+            'shared_access_key' => 'key-value',
+            'namespace' => 'namespace-name',
+        ], $result);
+    }
+
+    public function testParseInvalidDsnThrowsException(): void
+    {
+        $parser = new DsnParser();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Invalid Azure Service Bus DSN for the "my-transport" transport. ' .
+            'It must be in the following format: azure://SharedAccessKeyName:SharedAccessKey@namespace'
+        );
+        $this->expectExceptionCode(1643988474);
+
+        $parser->parseDsn('', 'my-transport');
+    }
+}

--- a/tests/Messenger/Transport/SasTokenGeneratorTest.php
+++ b/tests/Messenger/Transport/SasTokenGeneratorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Messenger\Transport;
+
+use AymDev\MessengerAzureBundle\Messenger\Transport\SasTokenGenerator;
+use PHPUnit\Framework\TestCase;
+
+class SasTokenGeneratorTest extends TestCase
+{
+    public function testGenerator(): void
+    {
+        $generator = new SasTokenGenerator(
+            'http://Endpoint',
+            'myAccessKeyName',
+            'myAccessKey',
+            60
+        );
+
+        $token = $generator->generateSharedAccessSignatureToken();
+
+        self::assertStringStartsWith('SharedAccessSignature ', $token);
+        parse_str(substr($token, strlen('SharedAccessSignature ')), $tokenParameters);
+
+        self::assertArrayHasKey('sig', $tokenParameters);
+        self::assertArrayHasKey('se', $tokenParameters);
+        self::assertArrayHasKey('skn', $tokenParameters);
+        self::assertArrayHasKey('sr', $tokenParameters);
+
+        self::assertNotEmpty($tokenParameters['sig']);
+        self::assertEqualsWithDelta(time() + 60, $tokenParameters['se'], 5);
+        self::assertSame('myAccessKeyName', $tokenParameters['skn']);
+        self::assertSame('http://endpoint', $tokenParameters['sr']);
+    }
+}


### PR DESCRIPTION
Currently a SAS token is generated by `AzureHttpClientConfigurationBuilder` when `AzureTransport` is created, with default 1 hour expiration time. That basically means that when I run `bin/console messenger:consume`, it can run for 1 hour and then fails with 403 error, because the SAS token expires.

This change moves the token generation into the HTTP client, so a new token is generated for each request, allowing the consumer to run indefinitely (in theory).