### PR TITLE
Allow passing all supported configuration using DSN and options

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,11 @@
 parameters:
-	level: 9
-	paths:
-	    - src
-	    - tests
-	bootstrapFiles:
-	    - vendor/bin/.phpunit/phpunit-9.5-0/vendor/autoload.php
+    level: 9
+    paths:
+        - src
+        - tests
+    bootstrapFiles:
+        - vendor/bin/.phpunit/phpunit-9.5-0/vendor/autoload.php
+    ignoreErrors:
+        - message: '#^Class AymDev\\MessengerAzureBundle\\Messenger\\Transport\\AzureTransportFactory implements generic interface Symfony\\Component\\Messenger\\Transport\\TransportFactoryInterface but does not specify its types\: TTransport$#'
+          path: src/Messenger/Transport/AzureTransportFactory.php
+          reportUnmatched: false

--- a/src/Messenger/Transport/AzureHttpClientConfigurationBuilder.php
+++ b/src/Messenger/Transport/AzureHttpClientConfigurationBuilder.php
@@ -17,11 +17,10 @@ final class AzureHttpClientConfigurationBuilder
      *     shared_access_key_name: string,
      *     shared_access_key: string,
      *     namespace: string,
-     * } $dsnParts
-     * @param array{
      *     entity_path: string,
-     *     token_expiry: int,
      *     subscription: string|null,
+     *     token_expiry: int,
+     *     receive_mode: AzureTransport::RECEIVE_MODE_*,
      * } $options
      * @return array{
      *     endpoint: string,
@@ -31,9 +30,9 @@ final class AzureHttpClientConfigurationBuilder
      *     options: array{headers: array<string, string>},
      * }
      */
-    public function buildSenderConfiguration(array $dsnParts, array $options): array
+    public function buildSenderConfiguration(array $options): array
     {
-        return $this->buildConfiguration(false, $dsnParts, $options);
+        return $this->buildConfiguration(false, $options);
     }
 
     /**
@@ -43,11 +42,10 @@ final class AzureHttpClientConfigurationBuilder
      *     shared_access_key_name: string,
      *     shared_access_key: string,
      *     namespace: string,
-     * } $dsnParts
-     * @param array{
      *     entity_path: string,
-     *     token_expiry: int,
      *     subscription: string|null,
+     *     token_expiry: int,
+     *     receive_mode: AzureTransport::RECEIVE_MODE_*,
      * } $options
      * @return array{
      *     endpoint: string,
@@ -57,9 +55,9 @@ final class AzureHttpClientConfigurationBuilder
      *     options: array{headers: array<string, string>},
      * }
      */
-    public function buildReceiverConfiguration(array $dsnParts, array $options): array
+    public function buildReceiverConfiguration(array $options): array
     {
-        return $this->buildConfiguration(true, $dsnParts, $options);
+        return $this->buildConfiguration(true, $options);
     }
 
     /**
@@ -67,11 +65,10 @@ final class AzureHttpClientConfigurationBuilder
      *     shared_access_key_name: string,
      *     shared_access_key: string,
      *     namespace: string,
-     * } $dsnParts
-     * @param array{
      *     entity_path: string,
-     *     token_expiry: int,
      *     subscription: string|null,
+     *     token_expiry: int,
+     *     receive_mode: AzureTransport::RECEIVE_MODE_*,
      * } $options
      * @return array{
      *     endpoint: string,
@@ -81,19 +78,19 @@ final class AzureHttpClientConfigurationBuilder
      *     options: array{headers: array<string, string>},
      * }
      */
-    private function buildConfiguration(bool $isReceiver, array $dsnParts, array $options): array
+    private function buildConfiguration(bool $isReceiver, array $options): array
     {
         $endpoint = $this->getBaseEndpoint(
             $isReceiver,
-            $dsnParts['namespace'],
+            $options['namespace'],
             $options['entity_path'],
             $options['subscription']
         );
 
         $clientOptions = [
             'endpoint' => $endpoint,
-            'shared_access_key_name' => $dsnParts['shared_access_key_name'],
-            'shared_access_key' => $dsnParts['shared_access_key'],
+            'shared_access_key_name' => $options['shared_access_key_name'],
+            'shared_access_key' => $options['shared_access_key'],
             'token_expiry' => $options['token_expiry'],
             'options' => [
                 'headers' => [],

--- a/src/Messenger/Transport/AzureTransportFactory.php
+++ b/src/Messenger/Transport/AzureTransportFactory.php
@@ -14,17 +14,6 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
  */
 final class AzureTransportFactory implements TransportFactoryInterface
 {
-    private const RECEIVE_MODES = [
-        AzureTransport::RECEIVE_MODE_PEEK_LOCK,
-        AzureTransport::RECEIVE_MODE_RECEIVE_AND_DELETE,
-    ];
-    private const DEFAULT_OPTIONS = [
-        'entity_path' => null,
-        'subscription' => null,
-        'token_expiry' => 3600,
-        'receive_mode' => AzureTransport::RECEIVE_MODE_PEEK_LOCK,
-    ];
-
     /** @var DsnParser */
     private $dsnParser;
 
@@ -57,11 +46,16 @@ final class AzureTransportFactory implements TransportFactoryInterface
      */
     public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
     {
-        $options = $this->validateOptions($options);
-        $dsnParts = $this->dsnParser->parseDsn($dsn, $options['transport_name']);
+        $transportName = $options['transport_name'];
+        if (!is_string($transportName)) {
+            throw new \InvalidArgumentException('The "transport_name" option must be set.');
+        }
+        unset($options['transport_name']);
 
-        $senderConfiguration = $this->httpClientConfigurationBuilder->buildSenderConfiguration($dsnParts, $options);
-        $receiverConfiguration = $this->httpClientConfigurationBuilder->buildReceiverConfiguration($dsnParts, $options);
+        $options = $this->dsnParser->parseDsn($dsn, $options, $transportName);
+
+        $senderConfiguration = $this->httpClientConfigurationBuilder->buildSenderConfiguration($options);
+        $receiverConfiguration = $this->httpClientConfigurationBuilder->buildReceiverConfiguration($options);
 
         return new AzureTransport(
             $serializer,
@@ -71,54 +65,5 @@ final class AzureTransportFactory implements TransportFactoryInterface
             $options['entity_path'],
             $options['subscription']
         );
-    }
-
-    /**
-     * Validate options and set default values
-     * @param mixed[] $options
-     * @return array{
-     *     transport_name: string,
-     *     entity_path: string,
-     *     subscription: string|null,
-     *     token_expiry: int,
-     *     receive_mode: string
-     * }
-     */
-    private function validateOptions(array $options): array
-    {
-        // Set default values
-        /**
-         * @var array{
-         *     transport_name: string,
-         *     entity_path: string|null,
-         *     subscription: string|null,
-         *     token_expiry: int,
-         *     receive_mode: string
-         * } $options
-         */
-        $options = array_merge(self::DEFAULT_OPTIONS, $options);
-
-        // Missing topic or queue name
-        if (null === $options['entity_path']) {
-            throw new \InvalidArgumentException(
-                sprintf('Missing entity_path (queue or topic) for the "%s" transport.', $options['transport_name']),
-                1643989596
-            );
-        }
-
-        // Invalid receive mode
-        if (false === in_array($options['receive_mode'], self::RECEIVE_MODES, true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Invalid "%s" receive_mode for the "%s" transport. It must be one of: %s.',
-                    $options['receive_mode'],
-                    $options['transport_name'],
-                    implode(', ', self::RECEIVE_MODES)
-                ),
-                1643994036
-            );
-        }
-
-        return $options;
     }
 }

--- a/src/Messenger/Transport/AzureTransportFactory.php
+++ b/src/Messenger/Transport/AzureTransportFactory.php
@@ -11,6 +11,8 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 /**
  * Messenger transport factory for Azure Service Bus
  * @internal
+ *
+ * @implements TransportFactoryInterface<AzureTransport>
  */
 final class AzureTransportFactory implements TransportFactoryInterface
 {

--- a/src/Messenger/Transport/AzureTransportFactory.php
+++ b/src/Messenger/Transport/AzureTransportFactory.php
@@ -11,8 +11,6 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 /**
  * Messenger transport factory for Azure Service Bus
  * @internal
- *
- * @implements TransportFactoryInterface<AzureTransport>
  */
 final class AzureTransportFactory implements TransportFactoryInterface
 {

--- a/src/Messenger/Transport/DsnParser.php
+++ b/src/Messenger/Transport/DsnParser.php
@@ -4,28 +4,131 @@ declare(strict_types=1);
 
 namespace AymDev\MessengerAzureBundle\Messenger\Transport;
 
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+
 class DsnParser
 {
+    private const RECEIVE_MODES = [
+        AzureTransport::RECEIVE_MODE_PEEK_LOCK,
+        AzureTransport::RECEIVE_MODE_RECEIVE_AND_DELETE,
+    ];
+
+    private const DEFAULT_OPTIONS = [
+        'shared_access_key_name' => null,
+        'shared_access_key' => null,
+        'namespace' => null,
+        'entity_path' => null,
+        'subscription' => null,
+        'token_expiry' => 3600,
+        'receive_mode' => AzureTransport::RECEIVE_MODE_PEEK_LOCK,
+    ];
+
     /**
-     * Parse the DSN to extract the namespace and shared access key
+     * Parse the DSN and merges it with options.
+     *
+     * @param mixed[] $options
      * @return array{
      *     shared_access_key_name: string,
      *     shared_access_key: string,
      *     namespace: string,
+     *     entity_path: string,
+     *     subscription: string|null,
+     *     token_expiry: int,
+     *     receive_mode: AzureTransport::RECEIVE_MODE_*,
      * }
      */
-    public function parseDsn(string $dsn, string $transportName): array
+    public function parseDsn(string $dsn, array $options, string $transportName): array
     {
-        if (1 !== preg_match('~^azure://(.+):(.+)@(.+)$~', $dsn, $matches)) {
+        $parsedUrl = parse_url($dsn);
+        if (false === $parsedUrl || ($parsedUrl['scheme'] ?? '') !== 'azure') {
             $message = sprintf('Invalid Azure Service Bus DSN for the "%s" transport. ', $transportName);
             $message .= 'It must be in the following format: azure://SharedAccessKeyName:SharedAccessKey@namespace';
-            throw new \InvalidArgumentException($message, 1643988474);
+            throw new InvalidArgumentException($message, 1643988474);
         }
 
-        return [
-            'shared_access_key_name' => $matches[1],
-            'shared_access_key' => $matches[2],
-            'namespace' => $matches[3],
-        ];
+        $query = [];
+        if (isset($parsedUrl['query'])) {
+            parse_str($parsedUrl['query'], $query);
+        }
+
+        // check for extra keys in options
+        $optionsExtraKeys = array_diff(array_keys($options), array_keys(self::DEFAULT_OPTIONS));
+        if (0 < count($optionsExtraKeys)) {
+            throw new InvalidArgumentException(sprintf(
+                'Unknown option found: [%s]. Allowed options are [%s].',
+                implode(', ', $optionsExtraKeys),
+                implode(', ', array_keys(self::DEFAULT_OPTIONS))
+            ));
+        }
+
+        // check for extra keys in query
+        $queryExtraKeys = array_diff(array_keys($query), array_keys(self::DEFAULT_OPTIONS));
+        if (0 < count($queryExtraKeys)) {
+            throw new InvalidArgumentException(sprintf(
+                'Unknown option found in DSN: [%s]. Allowed options are [%s].',
+                implode(', ', $queryExtraKeys),
+                implode(', ', array_keys(self::DEFAULT_OPTIONS))
+            ));
+        }
+
+        $options = $query + $options + self::DEFAULT_OPTIONS;
+        /** @var array{
+         *      shared_access_key_name: string|null,
+         *      shared_access_key: string|null,
+         *      namespace: string|null,
+         *      entity_path: string|null,
+         *      subscription: string|null,
+         *      token_expiry: int|string,
+         *      receive_mode: AzureTransport::RECEIVE_MODE_*,
+         * } $options
+         */
+
+        $options['shared_access_key_name'] = $this->pickOption('shared_access_key_name', 'user', $parsedUrl, $options);
+        $options['shared_access_key'] = $this->pickOption('shared_access_key', 'pass', $parsedUrl, $options);
+        $options['namespace'] = $this->pickOption('namespace', 'host', $parsedUrl, $options);
+        $options['token_expiry'] = (int) $options['token_expiry'];
+
+        // Missing topic or queue name
+        if (null === $options['entity_path']) {
+            throw new InvalidArgumentException(
+                sprintf('Missing entity_path (queue or topic) for the "%s" transport.', $transportName),
+                1643989596
+            );
+        }
+
+        // Invalid receive mode
+        if (false === in_array($options['receive_mode'], self::RECEIVE_MODES, true)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid "%s" receive_mode for the "%s" transport. It must be one of: %s.',
+                    $options['receive_mode'],
+                    $transportName,
+                    implode(', ', self::RECEIVE_MODES)
+                ),
+                1643994036
+            );
+        }
+
+        // @phpstan-ignore-next-line after all those array merges PHPstan gets confused about the result shape
+        return $options;
+    }
+
+    /**
+     * @param array<string, int|string> $dsnParts
+     * @param array<string, mixed> $options
+     * @return mixed
+     */
+    private function pickOption(string $optionName, string $dsnName, array $dsnParts, array $options)
+    {
+        $dsnValue = $dsnParts[$dsnName] ?? '';
+        if ($dsnValue !== '') {
+            return urldecode((string) $dsnValue);
+        }
+
+        if (isset($options[$optionName])) {
+            return $options[$optionName];
+        }
+
+        return self::DEFAULT_OPTIONS[$optionName];
     }
 }

--- a/src/Messenger/Transport/DsnParser.php
+++ b/src/Messenger/Transport/DsnParser.php
@@ -73,20 +73,44 @@ class DsnParser
 
         $options = $query + $options + self::DEFAULT_OPTIONS;
 
-        // Missing topic or queue name
-        if (null === $options['entity_path']) {
+        if (!is_string($options['entity_path'])) {
             throw new InvalidArgumentException(
-                sprintf('Missing entity_path (queue or topic) for the "%s" transport.', $transportName),
+                sprintf(
+                    'Invalid "entity_path" (queue or topic) for the "%s" transport. Expected string, got %s',
+                    $transportName,
+                    get_debug_type($options['entity_path']),
+                ),
                 1643989596
             );
         }
 
-        // Invalid receive mode
+        if (!is_string($options['subscription']) && null !== $options['subscription']) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid "subscription" for the "%s" transport. Expected string, got %s',
+                    $transportName,
+                    get_debug_type($options['subscription']),
+                ),
+                1643989596
+            );
+        }
+
+        if (!is_int($options['token_expiry']) && !ctype_digit($options['token_expiry'])) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid "token_expiry" for the "%s" transport. Expected integer, got %s',
+                    $transportName,
+                    get_debug_type($options['token_expiry']),
+                ),
+                1643989596
+            );
+        }
+
         if (false === in_array($options['receive_mode'], self::RECEIVE_MODES, true)) {
             throw new InvalidArgumentException(
                 sprintf(
                     'Invalid "%s" receive_mode for the "%s" transport. It must be one of: %s.',
-                    $options['receive_mode'],
+                    is_scalar($options['receive_mode']) ? $options['receive_mode'] : get_debug_type($options['receive_mode']),
                     $transportName,
                     implode(', ', self::RECEIVE_MODES)
                 ),
@@ -107,7 +131,7 @@ class DsnParser
 
     /**
      * @param array<string, int|string> $dsnParts
-     * @param array<string, string|null> $options
+     * @param mixed[] $options
      */
     private function pickOption(
         string $optionName,
@@ -122,6 +146,18 @@ class DsnParser
         }
 
         if (isset($options[$optionName])) {
+            if (!is_string($options[$optionName])) {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        'Invalid "%s" for the "%s" transport. Expected string, got %s',
+                        $optionName,
+                        $transportName,
+                        get_debug_type($options[$optionName]),
+                    ),
+                    1702724695
+                );
+            }
+
             return $options[$optionName];
         }
 

--- a/src/Messenger/Transport/DsnParser.php
+++ b/src/Messenger/Transport/DsnParser.php
@@ -110,7 +110,9 @@ class DsnParser
             throw new InvalidArgumentException(
                 sprintf(
                     'Invalid "%s" receive_mode for the "%s" transport. It must be one of: %s.',
-                    is_scalar($options['receive_mode']) ? $options['receive_mode'] : get_debug_type($options['receive_mode']),
+                    is_scalar($options['receive_mode']) ?
+                        $options['receive_mode'] :
+                        get_debug_type($options['receive_mode']),
                     $transportName,
                     implode(', ', self::RECEIVE_MODES)
                 ),
@@ -119,13 +121,31 @@ class DsnParser
         }
 
         return [
-            'shared_access_key_name' =>  $this->pickOption('shared_access_key_name', 'user', $parsedUrl, $options, $transportName),
-            'shared_access_key' =>  $this->pickOption('shared_access_key', 'pass', $parsedUrl, $options, $transportName),
-            'namespace' =>  $this->pickOption('namespace', 'host', $parsedUrl, $options, $transportName),
-            'entity_path' =>  $options['entity_path'],
-            'subscription' =>  $options['subscription'],
-            'token_expiry' =>  (int) $options['token_expiry'],
-            'receive_mode' =>  $options['receive_mode'],
+            'shared_access_key_name' => $this->pickOption(
+                'shared_access_key_name',
+                'user',
+                $parsedUrl,
+                $options,
+                $transportName,
+            ),
+            'shared_access_key' => $this->pickOption(
+                'shared_access_key',
+                'pass',
+                $parsedUrl,
+                $options,
+                $transportName,
+            ),
+            'namespace' => $this->pickOption(
+                'namespace',
+                'host',
+                $parsedUrl,
+                $options,
+                $transportName,
+            ),
+            'entity_path' => $options['entity_path'],
+            'subscription' => $options['subscription'],
+            'token_expiry' => (int) $options['token_expiry'],
+            'receive_mode' => $options['receive_mode'],
         ];
     }
 

--- a/src/Messenger/Transport/DsnParser.php
+++ b/src/Messenger/Transport/DsnParser.php
@@ -95,7 +95,10 @@ class DsnParser
             );
         }
 
-        if (!is_int($options['token_expiry']) && !ctype_digit($options['token_expiry'])) {
+        if (
+            !is_int($options['token_expiry']) &&
+            !(is_string($options['token_expiry']) && ctype_digit($options['token_expiry']))
+        ) {
             throw new InvalidArgumentException(
                 sprintf(
                     'Invalid "token_expiry" for the "%s" transport. Expected integer, got %s',

--- a/tests/Messenger/Transport/AzureHttpClientConfigurationBuilderTest.php
+++ b/tests/Messenger/Transport/AzureHttpClientConfigurationBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\AymDev\MessengerAzureBundle\Messenger\Transport;
 
 use AymDev\MessengerAzureBundle\Messenger\Transport\AzureHttpClientConfigurationBuilder;
+use AymDev\MessengerAzureBundle\Messenger\Transport\AzureTransport;
 use PHPUnit\Framework\TestCase;
 
 final class AzureHttpClientConfigurationBuilderTest extends TestCase
@@ -40,22 +41,21 @@ final class AzureHttpClientConfigurationBuilderTest extends TestCase
      */
     public function provideClientConfiguration(): array
     {
-        $dsnParts = [
+        $options = [
             'shared_access_key_name' => 'KeyName',
             'shared_access_key' => 'Key',
             'namespace' => 'namespace',
-        ];
-        $options = [
             'entity_path' => 'entity',
             'subscription' => null,
             'token_expiry' => 3600,
+            'receive_mode' => AzureTransport::RECEIVE_MODE_PEEK_LOCK,
         ];
 
         $factory = new AzureHttpClientConfigurationBuilder();
 
         return [
-            [true, $factory->buildSenderConfiguration($dsnParts, $options)],
-            [false, $factory->buildReceiverConfiguration($dsnParts, $options)],
+            [true, $factory->buildSenderConfiguration($options)],
+            [false, $factory->buildReceiverConfiguration($options)],
         ];
     }
 
@@ -64,16 +64,18 @@ final class AzureHttpClientConfigurationBuilderTest extends TestCase
      */
     public function testTopicReceiverConfiguration(): void
     {
-        $factory = new AzureHttpClientConfigurationBuilder();
-        $configuration = $factory->buildReceiverConfiguration([
+        $options = [
             'shared_access_key_name' => 'KeyName',
             'shared_access_key' => 'Key',
             'namespace' => 'namespace',
-        ], [
             'entity_path' => 'entity',
             'subscription' => 'subscription',
             'token_expiry' => 3600,
-        ]);
+            'receive_mode' => AzureTransport::RECEIVE_MODE_PEEK_LOCK,
+        ];
+
+        $factory = new AzureHttpClientConfigurationBuilder();
+        $configuration = $factory->buildReceiverConfiguration($options);
 
         // It MUST end with a trailing slash
         self::assertSame(

--- a/tests/Messenger/Transport/AzureTransportFactoryTest.php
+++ b/tests/Messenger/Transport/AzureTransportFactoryTest.php
@@ -77,27 +77,4 @@ final class AzureTransportFactoryTest extends TestCase
             self::createMock(SerializerInterface::class)
         );
     }
-
-    /**
-     * The factory must return an Azure transport
-     */
-    public function testCreateTransport(): void
-    {
-        $factory = new AzureTransportFactory(
-            new DsnParser(),
-            new AzureHttpClientConfigurationBuilder(),
-            new AzureHttpClientFactory()
-        );
-
-        $transport = $factory->createTransport(
-            'azure://KeyName:Key@namespace',
-            [
-                'transport_name' => 'test-transport',
-                'entity_path' => 'entity',
-            ],
-            self::createMock(SerializerInterface::class)
-        );
-
-        self::assertInstanceOf(AzureTransport::class, $transport);
-    }
 }

--- a/tests/Messenger/Transport/AzureTransportFactoryTest.php
+++ b/tests/Messenger/Transport/AzureTransportFactoryTest.php
@@ -77,4 +77,30 @@ final class AzureTransportFactoryTest extends TestCase
             self::createMock(SerializerInterface::class)
         );
     }
+
+    /**
+     * The factory must return an Azure transport
+     */
+    public function testCreateTransport(): void
+    {
+        $factory = new AzureTransportFactory(
+            new DsnParser(),
+            new AzureHttpClientConfigurationBuilder(),
+            new AzureHttpClientFactory()
+        );
+
+        $transport = $factory->createTransport(
+            'azure://KeyName:Key@namespace',
+            [
+                'transport_name' => 'test-transport',
+                'entity_path' => 'entity',
+            ],
+            self::createMock(SerializerInterface::class)
+        );
+
+        // PHPStan is clever enough to realize that the transport is an AzureTransport but
+        // the createTransport method technically still returns a TransportInterface
+        // @phpstan-ignore-next-line
+        self::assertInstanceOf(AzureTransport::class, $transport);
+    }
 }

--- a/tests/Messenger/Transport/AzureTransportFactoryTest.php
+++ b/tests/Messenger/Transport/AzureTransportFactoryTest.php
@@ -98,9 +98,6 @@ final class AzureTransportFactoryTest extends TestCase
             self::createMock(SerializerInterface::class)
         );
 
-        // PHPStan is clever enough to realize that the transport is an AzureTransport but
-        // the createTransport method technically still returns a TransportInterface
-        // @phpstan-ignore-next-line
         self::assertInstanceOf(AzureTransport::class, $transport);
     }
 }

--- a/tests/Messenger/Transport/DsnParserTest.php
+++ b/tests/Messenger/Transport/DsnParserTest.php
@@ -12,26 +12,196 @@ class DsnParserTest extends TestCase
     public function testParseValidDsn(): void
     {
         $parser = new DsnParser();
-        $result = $parser->parseDsn('azure://key-name:key-value@namespace-name', 'my-transport');
+        $result = $parser->parseDsn(
+            'azure://key-name:key-value@namespace-name',
+            ['entity_path' => 'path'],
+            'my-transport',
+        );
 
-        self::assertSame([
+        self::assertEquals([
+            'entity_path' => 'path',
             'shared_access_key_name' => 'key-name',
             'shared_access_key' => 'key-value',
             'namespace' => 'namespace-name',
+            'subscription' => null,
+            'token_expiry' => 3600,
+            'receive_mode' => 'peek-lock',
         ], $result);
     }
 
-    public function testParseInvalidDsnThrowsException(): void
+    public function testDsnOptionsAreUrlDecoded(): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parseDsn(
+            'azure://key%20name:key%20value@namespace%20name?entity_path=entity%20path',
+            [],
+            'my-transport',
+        );
+
+        self::assertEquals([
+            'entity_path' => 'entity path',
+            'shared_access_key_name' => 'key name',
+            'shared_access_key' => 'key value',
+            'namespace' => 'namespace name',
+            'subscription' => null,
+            'token_expiry' => 3600,
+            'receive_mode' => 'peek-lock',
+        ], $result);
+    }
+
+    /**
+     * @return iterable<string, array{dsn: string, options: mixed[], expected: mixed[]}>
+     */
+    public function provideMergingOrderTestData(): iterable
+    {
+        yield 'dsn options' => [
+            'dsn' => 'azure://key-name:key-value@namespace-name?entity_path=entity-path&token_expiry=7200',
+            'options' => [
+                'shared_access_key_name' => 'from-options',
+                'shared_access_key' => 'from-options',
+                'namespace' => 'from-options',
+                'entity_path' => 'from-options',
+                'token_expiry' => 1600,
+            ],
+            'expected' => [
+                'entity_path' => 'entity-path',
+                'token_expiry' => 7200,
+                'shared_access_key_name' => 'key-name',
+                'shared_access_key' => 'key-value',
+                'namespace' => 'namespace-name',
+                'subscription' => null,
+                'receive_mode' => 'peek-lock',
+            ],
+        ];
+
+        yield 'regular options' => [
+            'dsn' => 'azure://namespace-name',
+            'options' => [
+                'shared_access_key_name' => 'key-name',
+                'shared_access_key' => 'key-value',
+                'entity_path' => 'entity-path',
+            ],
+            'expected' => [
+                'shared_access_key_name' => 'key-name',
+                'shared_access_key' => 'key-value',
+                'entity_path' => 'entity-path',
+                'namespace' => 'namespace-name',
+                'subscription' => null,
+                'token_expiry' => 3600,
+                'receive_mode' => 'peek-lock',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMergingOrderTestData
+     * @param mixed[] $options
+     * @param mixed[] $expectedResult
+     */
+    public function testOptionsMergingOrder(string $dsn, array $options, array $expectedResult): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parseDsn($dsn, $options, 'my-transport');
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @return iterable<string, array{dsn: string, options: mixed[], error: string, code?: int}>
+     */
+    public static function provideInvalidConfigurations(): iterable
+    {
+        yield 'unparseable DSN' => [
+            'dsn' => 'http://?',
+            'options' => [],
+            'error' =>
+                'Invalid Azure Service Bus DSN for the "my-transport" transport. ' .
+                'It must be in the following format: azure://SharedAccessKeyName:SharedAccessKey@namespace',
+            'code' => 1643988474,
+        ];
+
+        yield 'wrong scheme' => [
+            'dsn' => 'http://SharedAccessKeyName:SharedAccessKey@namespace',
+            'options' => [],
+            'error' =>
+                'Invalid Azure Service Bus DSN for the "my-transport" transport. ' .
+                'It must be in the following format: azure://SharedAccessKeyName:SharedAccessKey@namespace',
+            'code' => 1643988474,
+        ];
+
+        yield 'unknown option' => [
+            'dsn' => 'azure://SharedAccessKeyName:SharedAccessKey@namespace',
+            'options' => ['foo' => 'bar'],
+            'error' =>
+                'Unknown option found: [foo]. ' .
+                'Allowed options are [shared_access_key_name, shared_access_key, namespace, entity_path, ' .
+                'subscription, token_expiry, receive_mode].',
+        ];
+
+        yield 'unknown query param' => [
+            'dsn' => 'azure://SharedAccessKeyName:SharedAccessKey@namespace?foo=bar',
+            'options' => [],
+            'error' =>
+                'Unknown option found in DSN: [foo]. ' .
+                'Allowed options are [shared_access_key_name, shared_access_key, namespace, entity_path, ' .
+                'subscription, token_expiry, receive_mode].',
+        ];
+
+        yield 'missing entity_path' => [
+            'dsn' => 'azure://SharedAccessKeyName:SharedAccessKey@namespace',
+            'options' => [],
+            'error' => 'Missing entity_path (queue or topic) for the "my-transport" transport.',
+            'code' => 1643989596,
+        ];
+
+        yield 'invalid receive_mode (in options)' => [
+            'dsn' => 'azure://SharedAccessKeyName:SharedAccessKey@namespace',
+            'options' => [
+                'entity_path' => 'foo',
+                'receive_mode' => 'foo',
+            ],
+            'error' => 'Invalid "foo" receive_mode for the "my-transport" transport. It must be one of: ' .
+                'peek-lock, receive-and-delete.',
+            'code' => 1643994036,
+        ];
+
+        yield 'invalid receive_mode (in DNS)' => [
+            'dsn' => 'azure://SharedAccessKeyName:SharedAccessKey@namespace?receive_mode=foo',
+            'options' => [
+                'entity_path' => 'foo',
+            ],
+            'error' => 'Invalid "foo" receive_mode for the "my-transport" transport. It must be one of: ' .
+                'peek-lock, receive-and-delete.',
+            'code' => 1643994036,
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidConfigurations
+     * @param mixed[] $options
+     */
+    public function testInvalidConfigThrowsException(
+        string $dsn,
+        array $options,
+        string $expectedError,
+        int $expectedCode = 0
+    ): void {
+        $parser = new DsnParser();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedError);
+        $this->expectExceptionCode($expectedCode);
+
+        $parser->parseDsn($dsn, $options, 'my-transport');
+    }
+
+    public function testInvalidReceiveModeThrowsException(): void
     {
         $parser = new DsnParser();
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'Invalid Azure Service Bus DSN for the "my-transport" transport. ' .
-            'It must be in the following format: azure://SharedAccessKeyName:SharedAccessKey@namespace'
-        );
-        $this->expectExceptionCode(1643988474);
+        $this->expectExceptionMessage('Missing entity_path (queue or topic) for the "my-transport" transport.');
 
-        $parser->parseDsn('', 'my-transport');
+        $parser->parseDsn('azure://SharedAccessKeyName:SharedAccessKey@namespac', [], 'my-transport');
     }
 }

--- a/tests/Messenger/Transport/DsnParserTest.php
+++ b/tests/Messenger/Transport/DsnParserTest.php
@@ -150,7 +150,9 @@ class DsnParserTest extends TestCase
         yield 'missing entity_path' => [
             'dsn' => 'azure://SharedAccessKeyName:SharedAccessKey@namespace',
             'options' => [],
-            'error' => 'Invalid "entity_path" (queue or topic) for the "my-transport" transport. Expected string, got null',
+            'error' =>
+                'Invalid "entity_path" (queue or topic) for the "my-transport" transport. ' .
+                'Expected string, got null',
             'code' => 1643989596,
         ];
 
@@ -159,7 +161,9 @@ class DsnParserTest extends TestCase
             'options' => [
                 'entity_path' => 123,
             ],
-            'error' => 'Invalid "entity_path" (queue or topic) for the "my-transport" transport. Expected string, got int',
+            'error' =>
+                'Invalid "entity_path" (queue or topic) for the "my-transport" transport. ' .
+                'Expected string, got int',
             'code' => 1643989596,
         ];
 

--- a/tests/Messenger/Transport/DsnParserTest.php
+++ b/tests/Messenger/Transport/DsnParserTest.php
@@ -64,12 +64,12 @@ class DsnParserTest extends TestCase
                 'token_expiry' => 1600,
             ],
             'expected' => [
-                'entity_path' => 'entity-path',
-                'token_expiry' => 7200,
                 'shared_access_key_name' => 'key-name',
                 'shared_access_key' => 'key-value',
                 'namespace' => 'namespace-name',
+                'entity_path' => 'entity-path',
                 'subscription' => null,
+                'token_expiry' => 7200,
                 'receive_mode' => 'peek-lock',
             ],
         ];
@@ -84,8 +84,8 @@ class DsnParserTest extends TestCase
             'expected' => [
                 'shared_access_key_name' => 'key-name',
                 'shared_access_key' => 'key-value',
-                'entity_path' => 'entity-path',
                 'namespace' => 'namespace-name',
+                'entity_path' => 'entity-path',
                 'subscription' => null,
                 'token_expiry' => 3600,
                 'receive_mode' => 'peek-lock',
@@ -173,6 +173,24 @@ class DsnParserTest extends TestCase
             'error' => 'Invalid "foo" receive_mode for the "my-transport" transport. It must be one of: ' .
                 'peek-lock, receive-and-delete.',
             'code' => 1643994036,
+        ];
+
+        yield 'missing shared_access_key_name' => [
+            'dsn' => 'azure://:SharedAccessKey@namespace?receive_mode=peek-lock',
+            'options' => [
+                'entity_path' => 'foo',
+            ],
+            'error' => 'Missing shared_access_key_name for the "my-transport" transport.',
+            'code' => 1702724695,
+        ];
+
+        yield 'missing shared_access_key' => [
+            'dsn' => 'azure://SharedAccessKeyName@namespace?receive_mode=peek-lock',
+            'options' => [
+                'entity_path' => 'foo',
+            ],
+            'error' => 'Missing shared_access_key for the "my-transport" transport.',
+            'code' => 1702724695,
         ];
     }
 

--- a/tests/Messenger/Transport/DsnParserTest.php
+++ b/tests/Messenger/Transport/DsnParserTest.php
@@ -150,7 +150,45 @@ class DsnParserTest extends TestCase
         yield 'missing entity_path' => [
             'dsn' => 'azure://SharedAccessKeyName:SharedAccessKey@namespace',
             'options' => [],
-            'error' => 'Missing entity_path (queue or topic) for the "my-transport" transport.',
+            'error' => 'Invalid "entity_path" (queue or topic) for the "my-transport" transport. Expected string, got null',
+            'code' => 1643989596,
+        ];
+
+        yield 'invalid entity_path' => [
+            'dsn' => 'azure://SharedAccessKeyName:SharedAccessKey@namespace',
+            'options' => [
+                'entity_path' => 123,
+            ],
+            'error' => 'Invalid "entity_path" (queue or topic) for the "my-transport" transport. Expected string, got int',
+            'code' => 1643989596,
+        ];
+
+        yield 'invalid subscription' => [
+            'dsn' => 'azure://SharedAccessKeyName:SharedAccessKey@namespace',
+            'options' => [
+                'entity_path' => 'foo',
+                'subscription' => 123,
+            ],
+            'error' => 'Invalid "subscription" for the "my-transport" transport. Expected string, got int',
+            'code' => 1643989596,
+        ];
+
+        yield 'invalid token_expiry (in options)' => [
+            'dsn' => 'azure://SharedAccessKeyName:SharedAccessKey@namespace',
+            'options' => [
+                'entity_path' => 'foo',
+                'token_expiry' => 123.45,
+            ],
+            'error' => 'Invalid "token_expiry" for the "my-transport" transport. Expected integer, got float',
+            'code' => 1643989596,
+        ];
+
+        yield 'invalid token_expiry (in DSN)' => [
+            'dsn' => 'azure://SharedAccessKeyName:SharedAccessKey@namespace?token_expiry=123.45',
+            'options' => [
+                'entity_path' => 'foo',
+            ],
+            'error' => 'Invalid "token_expiry" for the "my-transport" transport. Expected integer, got string',
             'code' => 1643989596,
         ];
 
@@ -184,12 +222,32 @@ class DsnParserTest extends TestCase
             'code' => 1702724695,
         ];
 
+        yield 'invalid shared_access_key_name' => [
+            'dsn' => 'azure://:SharedAccessKey@namespace?receive_mode=peek-lock',
+            'options' => [
+                'entity_path' => 'foo',
+                'shared_access_key_name' => 123,
+            ],
+            'error' => 'Invalid "shared_access_key_name" for the "my-transport" transport. Expected string, got int',
+            'code' => 1702724695,
+        ];
+
         yield 'missing shared_access_key' => [
             'dsn' => 'azure://SharedAccessKeyName@namespace?receive_mode=peek-lock',
             'options' => [
                 'entity_path' => 'foo',
             ],
             'error' => 'Missing shared_access_key for the "my-transport" transport.',
+            'code' => 1702724695,
+        ];
+
+        yield 'invalid shared_access_key' => [
+            'dsn' => 'azure://SharedAccessKeyName@namespace?receive_mode=peek-lock',
+            'options' => [
+                'entity_path' => 'foo',
+                'shared_access_key' => 123,
+            ],
+            'error' => 'Invalid "shared_access_key" for the "my-transport" transport. Expected string, got int',
             'code' => 1702724695,
         ];
     }
@@ -211,15 +269,5 @@ class DsnParserTest extends TestCase
         $this->expectExceptionCode($expectedCode);
 
         $parser->parseDsn($dsn, $options, 'my-transport');
-    }
-
-    public function testInvalidReceiveModeThrowsException(): void
-    {
-        $parser = new DsnParser();
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Missing entity_path (queue or topic) for the "my-transport" transport.');
-
-        $parser->parseDsn('azure://SharedAccessKeyName:SharedAccessKey@namespac', [], 'my-transport');
     }
 }


### PR DESCRIPTION
According to Messenger [docs](https://symfony.com/doc/current/messenger.html#transport-configuration), transport options can be passed using both DSN and `options` config, which is not currently possible here.

This PR adds support for supplying any config using both DSN and `options` config. The implementation is heavily inspired by https://github.com/symfony/amazon-sqs-messenger/blob/6.3/Transport/Connection.php. If the same option is supplied multiple times, value is looked up in following order:
* DNS query values
* config options
* default values

The implementation contains possible breaking change - originally the DSN was parsed using simple regex and values were then used as were. Now it uses `parse_url` + `urldecode`. This is again, to behave similarly as other transports does.
