### PR TITLE
chore: update dev tools and allow Symfony 8

### DIFF
--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -1,5 +1,5 @@
 name: Bundle installation
-on: push
+on: [push, pull_request]
 
 jobs:
     integration-tests:
@@ -7,11 +7,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: ['8.1', '8.2', '8.3']
-                symfony: ['5.4', '6.4', '7.0']
-                exclude:
-                    - php: '8.1'
-                      symfony: '7.0'
+                php: ['8.4', '8.5']
+                symfony: ['6.4', '7.4', '8.0']
 
         steps:
             # Setup

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -1,10 +1,13 @@
-name: Coding Standards
+name: Static Analysis
 on: [push, pull_request]
 
 jobs:
-    coding-standards:
-        name: PHP CodeSniffer
+    unit-tests:
+        name: PHP ${{ matrix.php }} - PHPStan
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                php: ['8.4', '8.5']
 
         steps:
             # Setup
@@ -14,7 +17,7 @@ jobs:
             -   name: PHP setup
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.4
+                    php-version: ${{ matrix.php }}
                     extensions: mbstring, xml, ctype, iconv, intl
                     coverage: xdebug
 
@@ -33,6 +36,6 @@ jobs:
             -   name: Install dependencies
                 run: composer install --prefer-dist
 
-            # Run PHP CodeSniffer
-            -   name: Run PHP CodeSniffer
-                run: php vendor/bin/phpcs
+            # Run PHPStan
+            -   name: Run PHPStan
+                run: php vendor/bin/phpstan

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -3,11 +3,8 @@ on: [push, pull_request]
 
 jobs:
     unit-tests:
-        name: PHP ${{ matrix.php }} - PHPUnit & PHPStan
+        name: PHPUnit
         runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                php: ['8.1', '8.2', '8.3']
 
         steps:
             # Setup
@@ -17,7 +14,7 @@ jobs:
             -   name: PHP setup
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: ${{ matrix.php }}
+                    php-version: 8.4
                     extensions: mbstring, xml, ctype, iconv, intl
                     coverage: xdebug
 
@@ -38,8 +35,4 @@ jobs:
 
             # Run tests suite
             -   name: Run test suite
-                run: php vendor/bin/simple-phpunit --coverage-text
-
-            # Run PHPStan
-            -   name: Run PHPStan
-                run: php vendor/bin/phpstan
+                run: php vendor/bin/phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - Symfony 8 support
+
+### Fixed
+ - changed TimeToLive broker property to a float: [PR #20](https://github.com/AymDev/MessengerAzureBundle/pull/20)
+
+### Changed
+- upgraded minimum supported version to **PHP 8.4** and **Symfony 6.4**
 
 ## [2.0.0] - 2024-02-14
 ### Removed

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: tests
 tests:
-	php ./vendor/bin/simple-phpunit
+	php ./vendor/bin/phpunit
 
 .PHONY: analysis
 analysis:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Messenger Azure Service Bus Bundle
-A **PHP 8.1+** & **Symfony 5 / 6 / 7** bundle providing a **Symfony Messenger** *transport* for **Azure Service Bus** using the *Azure REST API*.
+A **PHP 8.4+** & **Symfony 6 / 7 / 8** bundle providing a **Symfony Messenger** *transport* for **Azure Service Bus** using the *Azure REST API*.
 
 ![Testing](https://github.com/AymDev/MessengerAzureBundle/workflows/Testing/badge.svg)
 ![Coding Standards](https://github.com/AymDev/MessengerAzureBundle/workflows/Coding%20Standards/badge.svg)

--- a/composer.json
+++ b/composer.json
@@ -3,22 +3,22 @@
     "description": "Symfony Messenger bundle for Azure Service Bus",
     "type": "symfony-bundle",
     "require": {
-        "php": "^8.1",
+        "php": "^8.4",
         "ext-json": "*",
-        "symfony/messenger": "^5.4|^6.4|^7.0",
-        "symfony/http-kernel": "^5.4|^6.4|^7.0",
-        "symfony/dependency-injection": "^5.4|^6.4|^7.0",
-        "symfony/http-client": "^5.4|^6.4|^7.0"
+        "symfony/messenger": "^6.4|^7.4|^8.0",
+        "symfony/http-kernel": "^6.4|^7.4|^8.0",
+        "symfony/dependency-injection": "^6.4|^7.4|^8.0",
+        "symfony/http-client": "^6.4|^7.4|^8.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.6",
-        "phpstan/phpstan": "^1.4",
-        "symfony/phpunit-bridge": "^5.4|^6.4|^7.0",
+        "phpstan/phpstan": "^2.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "phpcompatibility/php-compatibility": "^9.3",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-strict-rules": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpunit/phpunit": "^13.0"
     },
     "license": "MIT",
     "authors": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,7 @@ parameters:
         - src
         - tests
     bootstrapFiles:
-        - vendor/bin/.phpunit/phpunit-9.5-0/vendor/autoload.php
+        - vendor/autoload.php
     ignoreErrors:
         - message: '#^Class AymDev\\MessengerAzureBundle\\Messenger\\Transport\\AzureTransportFactory implements generic interface Symfony\\Component\\Messenger\\Transport\\TransportFactoryInterface but does not specify its types\: TTransport$#'
           path: src/Messenger/Transport/AzureTransportFactory.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.0/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php">
+         bootstrap="vendor/autoload.php"
+>
 
     <php>
         <ini name="error_reporting" value="-1"/>
         <server name="APP_ENV" value="test" force="true"/>
         <server name="SHELL_VERBOSITY" value="-1"/>
-        <server name="SYMFONY_PHPUNIT_VERSION" value="9.5"/>
-        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
     </php>
 
     <testsuites>
@@ -19,10 +18,4 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <coverage>
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
 </phpunit>

--- a/src/Messenger/Exception/SerializerDecodingException.php
+++ b/src/Messenger/Exception/SerializerDecodingException.php
@@ -21,7 +21,7 @@ final class SerializerDecodingException extends MessageDecodingFailedException
     /**
      * @param Envelope $envelope an envelope with an empty message
      */
-    public function __construct(Envelope $envelope, string $message = "", int $code = 0, Throwable $previous = null)
+    public function __construct(Envelope $envelope, string $message = "", int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->envelope = $envelope;

--- a/src/Messenger/Transport/AzureTransport.php
+++ b/src/Messenger/Transport/AzureTransport.php
@@ -70,6 +70,15 @@ final class AzureTransport implements TransportInterface
             );
         }
 
+        $headers = array_map(
+            function ($h) {
+                $last = array_key_last($h);
+                return null === $last ? null : $h[$last];
+            },
+            $headers
+        );
+        $headers = array_filter($headers, is_string(...));
+
         // Decode message
         try {
             $envelope = $this->serializer->decode([
@@ -158,9 +167,6 @@ final class AzureTransport implements TransportInterface
 
         // Decode message
         $encodedMessage = $this->serializer->encode($envelope);
-        if (!isset($encodedMessage['body'])) {
-            throw new \LogicException('Missing encoded message body.', 1644403794);
-        }
         if (isset($encodedMessage['headers'])) {
             $additionalHeaders = array_merge($additionalHeaders, $encodedMessage['headers']);
         }

--- a/tests/Messenger/Stamp/AzureBrokerPropertiesStampTest.php
+++ b/tests/Messenger/Stamp/AzureBrokerPropertiesStampTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\AymDev\MessengerAzureBundle\Messenger\Stamp;
 
 use AymDev\MessengerAzureBundle\Messenger\Stamp\AzureBrokerPropertiesStamp;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -13,8 +14,8 @@ final class AzureBrokerPropertiesStampTest extends TestCase
 {
     /**
      * The "BrokerProperties" header and its properties must be optional
-     * @dataProvider provideMissingBrokerPropertiesResponses
      */
+    #[DataProvider('provideMissingBrokerPropertiesResponses')]
     public function testCreateFromResponseWithMissingProperties(MockResponse $mockResponse): void
     {
         $httpClient = new MockHttpClient([$mockResponse]);
@@ -43,7 +44,7 @@ final class AzureBrokerPropertiesStampTest extends TestCase
     /**
      * @return MockResponse[][]
      */
-    public function provideMissingBrokerPropertiesResponses(): array
+    public static function provideMissingBrokerPropertiesResponses(): array
     {
         return [
             [

--- a/tests/Messenger/Transport/AzureHttpClientConfigurationBuilderTest.php
+++ b/tests/Messenger/Transport/AzureHttpClientConfigurationBuilderTest.php
@@ -6,15 +6,16 @@ namespace Tests\AymDev\MessengerAzureBundle\Messenger\Transport;
 
 use AymDev\MessengerAzureBundle\Messenger\Transport\AzureHttpClientConfigurationBuilder;
 use AymDev\MessengerAzureBundle\Messenger\Transport\AzureTransport;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class AzureHttpClientConfigurationBuilderTest extends TestCase
 {
     /**
      * Check default configurations
-     * @dataProvider provideClientConfiguration
      * @param mixed[] $configuration
      */
+    #[DataProvider('provideClientConfiguration')]
     public function testDefaultConfiguration(bool $isSender, array $configuration): void
     {
         self::assertArrayHasKey('endpoint', $configuration);
@@ -39,7 +40,7 @@ final class AzureHttpClientConfigurationBuilderTest extends TestCase
     /**
      * @return mixed[][]
      */
-    public function provideClientConfiguration(): array
+    public static function provideClientConfiguration(): array
     {
         $options = [
             'shared_access_key_name' => 'KeyName',

--- a/tests/Messenger/Transport/AzureTransportFactoryTest.php
+++ b/tests/Messenger/Transport/AzureTransportFactoryTest.php
@@ -49,7 +49,7 @@ final class AzureTransportFactoryTest extends TestCase
             [
                 'transport_name' => 'test-transport',
             ],
-            self::createMock(SerializerInterface::class)
+            self::createStub(SerializerInterface::class)
         );
     }
 
@@ -74,7 +74,7 @@ final class AzureTransportFactoryTest extends TestCase
                 'entity_path' => 'entity',
                 'receive_mode' => 'invalid',
             ],
-            self::createMock(SerializerInterface::class)
+            self::createStub(SerializerInterface::class)
         );
     }
 
@@ -95,7 +95,7 @@ final class AzureTransportFactoryTest extends TestCase
                 'transport_name' => 'test-transport',
                 'entity_path' => 'entity',
             ],
-            self::createMock(SerializerInterface::class)
+            self::createStub(SerializerInterface::class)
         );
 
         self::assertInstanceOf(AzureTransport::class, $transport);

--- a/tests/Messenger/Transport/AzureTransportTest.php
+++ b/tests/Messenger/Transport/AzureTransportTest.php
@@ -9,6 +9,7 @@ use AymDev\MessengerAzureBundle\Messenger\Stamp\AzureMessageStamp;
 use AymDev\MessengerAzureBundle\Messenger\Transport\AzureTransport;
 use AymDev\MessengerAzureBundle\Messenger\Stamp\AzureBrokerPropertiesStamp;
 use AymDev\MessengerAzureBundle\Messenger\Stamp\AzureReceivedStamp;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -36,7 +37,7 @@ final class AzureTransportTest extends TestCase
         ]));
 
         $transport = new AzureTransport(
-            self::createMock(SerializerInterface::class),
+            self::createStub(SerializerInterface::class),
             new MockHttpClient(),
             $httpReceiver,
             AzureTransport::RECEIVE_MODE_PEEK_LOCK,
@@ -56,7 +57,7 @@ final class AzureTransportTest extends TestCase
         ]));
 
         $transport = new AzureTransport(
-            self::createMock(SerializerInterface::class),
+            self::createStub(SerializerInterface::class),
             new MockHttpClient(),
             $httpReceiver,
             AzureTransport::RECEIVE_MODE_PEEK_LOCK,
@@ -79,7 +80,7 @@ final class AzureTransportTest extends TestCase
         ]));
 
         $transport = new AzureTransport(
-            self::createMock(SerializerInterface::class),
+            self::createStub(SerializerInterface::class),
             new MockHttpClient(),
             $httpReceiver,
             AzureTransport::RECEIVE_MODE_PEEK_LOCK,
@@ -139,8 +140,8 @@ final class AzureTransportTest extends TestCase
 
     /**
      * Read messages must be returned in an envelope with specific stamps
-     * @dataProvider provideValidGetCases
      */
+    #[DataProvider('provideValidGetCases')]
     public function testGetHasStamps(
         int $statusCode,
         string $receiveMode,
@@ -214,7 +215,7 @@ final class AzureTransportTest extends TestCase
     /**
      * @return array{int, string, bool, ?string, ?string}[]
      */
-    public function provideValidGetCases(): array
+    public static function provideValidGetCases(): array
     {
         return [
             [
@@ -250,15 +251,15 @@ final class AzureTransportTest extends TestCase
 
     /**
      * The message acknowledgment or rejection must not do anything on the Receive And Delete receive mode
-     * @dataProvider provideDeletingMessageMethodNames
      */
+    #[DataProvider('provideDeletingMessageMethodNames')]
     public function testAckRejectDoesNotDeleteOnReceiveAndDeleteMode(string $methodName): void
     {
         $receiver = self::createMock(HttpClientInterface::class);
         $receiver->expects(self::never())->method('request');
 
         $transport = new AzureTransport(
-            self::createMock(SerializerInterface::class),
+            self::createStub(SerializerInterface::class),
             new MockHttpClient(),
             $receiver,
             AzureTransport::RECEIVE_MODE_RECEIVE_AND_DELETE,
@@ -274,8 +275,8 @@ final class AzureTransportTest extends TestCase
 
     /**
      * The message acknowledgment or rejection must delete using the delete location URL when available
-     * @dataProvider provideDeletingMessageMethodNames
      */
+    #[DataProvider('provideDeletingMessageMethodNames')]
     public function testAckRejectDeletesWithDeleteLocationWhenAvailable(string $methodName): void
     {
         $expectedUrl = 'https://test-domain-b.com/test-uri-b';
@@ -291,7 +292,7 @@ final class AzureTransportTest extends TestCase
         );
 
         $transport = new AzureTransport(
-            self::createMock(SerializerInterface::class),
+            self::createStub(SerializerInterface::class),
             new MockHttpClient(),
             $receiver,
             AzureTransport::RECEIVE_MODE_PEEK_LOCK,
@@ -309,15 +310,15 @@ final class AzureTransportTest extends TestCase
 
     /**
      * An exception must be thrown if there are no delete location nor broker properties
-     * @dataProvider provideDeletingMessageMethodNames
      */
+    #[DataProvider('provideDeletingMessageMethodNames')]
     public function testAckRejectWithoutDeleteLocationOrBrokerProperties(string $methodName): void
     {
         self::expectException(\LogicException::class);
         self::expectExceptionCode(1644340687);
 
         $transport = new AzureTransport(
-            self::createMock(SerializerInterface::class),
+            self::createStub(SerializerInterface::class),
             new MockHttpClient(),
             new MockHttpClient(),
             AzureTransport::RECEIVE_MODE_PEEK_LOCK,
@@ -336,15 +337,15 @@ final class AzureTransportTest extends TestCase
 
     /**
      * An exception must be thrown if there are no MessageId nor SequenceNumber in the broker properties
-     * @dataProvider provideDeletingMessageMethodNames
      */
+    #[DataProvider('provideDeletingMessageMethodNames')]
     public function testAckRejectWithoutBrokerPropertiesMessageIdentifier(string $methodName): void
     {
         self::expectException(\LogicException::class);
         self::expectExceptionCode(1644340921);
 
         $transport = new AzureTransport(
-            self::createMock(SerializerInterface::class),
+            self::createStub(SerializerInterface::class),
             new MockHttpClient(),
             new MockHttpClient(),
             AzureTransport::RECEIVE_MODE_PEEK_LOCK,
@@ -363,8 +364,8 @@ final class AzureTransportTest extends TestCase
 
     /**
      * An exception must be thrown if there is a MessageId or SequenceNumber but no LockToken in the broker properties
-     * @dataProvider provideBrokerPropertiesWithMissingLockToken
      */
+    #[DataProvider('provideBrokerPropertiesWithMissingLockToken')]
     public function testAckRejectWithoutBrokerPropertiesLockToken(
         string $methodName,
         AzureBrokerPropertiesStamp $stamp
@@ -373,7 +374,7 @@ final class AzureTransportTest extends TestCase
         self::expectExceptionCode(1644340926);
 
         $transport = new AzureTransport(
-            self::createMock(SerializerInterface::class),
+            self::createStub(SerializerInterface::class),
             new MockHttpClient(),
             new MockHttpClient(),
             AzureTransport::RECEIVE_MODE_PEEK_LOCK,
@@ -391,7 +392,7 @@ final class AzureTransportTest extends TestCase
     /**
      * @return array{string, AzureBrokerPropertiesStamp}[]
      */
-    public function provideBrokerPropertiesWithMissingLockToken(): iterable
+    public static function provideBrokerPropertiesWithMissingLockToken(): iterable
     {
         $stamps = [
             new AzureBrokerPropertiesStamp(
@@ -418,7 +419,7 @@ final class AzureTransportTest extends TestCase
             )
         ];
 
-        foreach ($this->provideDeletingMessageMethodNames() as [$methodName]) {
+        foreach (self::provideDeletingMessageMethodNames() as [$methodName]) {
             foreach ($stamps as $stamp) {
                 yield [
                     $methodName,
@@ -431,8 +432,8 @@ final class AzureTransportTest extends TestCase
     /**
      * The message acknowledgment or rejection must delete using the BrokerProperties when there is no delete location
      * but there is a message identifier and LockToken
-     * @dataProvider provideDeletingMessageMethodNames
      */
+    #[DataProvider('provideDeletingMessageMethodNames')]
     public function testAckRejectDeletesWithBrokerProperties(string $methodName): void
     {
         $messageId = 'test-message-id';
@@ -452,7 +453,7 @@ final class AzureTransportTest extends TestCase
         );
 
         $transport = new AzureTransport(
-            self::createMock(SerializerInterface::class),
+            self::createStub(SerializerInterface::class),
             new MockHttpClient(),
             $receiver,
             AzureTransport::RECEIVE_MODE_PEEK_LOCK,
@@ -479,8 +480,8 @@ final class AzureTransportTest extends TestCase
     /**
      * An exception from the HTTP client during the message acknowledgment or rejection must be converted to a transport
      * exception
-     * @dataProvider provideDeletingMessageMethodNames
      */
+    #[DataProvider('provideDeletingMessageMethodNames')]
     public function testAckRejectThrowsOnHttpError(string $methodName): void
     {
         self::expectException(TransportException::class);
@@ -491,7 +492,7 @@ final class AzureTransportTest extends TestCase
         ]));
 
         $transport = new AzureTransport(
-            self::createMock(SerializerInterface::class),
+            self::createStub(SerializerInterface::class),
             new MockHttpClient(),
             $receiver,
             AzureTransport::RECEIVE_MODE_PEEK_LOCK,
@@ -510,7 +511,7 @@ final class AzureTransportTest extends TestCase
     /**
      * @return string[][]
      */
-    public function provideDeletingMessageMethodNames(): array
+    public static function provideDeletingMessageMethodNames(): array
     {
         return [
             ['ack'],
@@ -603,34 +604,7 @@ final class AzureTransportTest extends TestCase
         ]);
 
         $transport = new AzureTransport(
-            self::createMock(SerializerInterface::class),
-            new MockHttpClient(),
-            new MockHttpClient(),
-            AzureTransport::RECEIVE_MODE_RECEIVE_AND_DELETE,
-            'entity'
-        );
-
-        $transport->send($envelope);
-    }
-
-    /**
-     * The encoded enveloppe must have a "body" key
-     */
-    public function testSentEncodedEnvelopeMustHaveABody(): void
-    {
-        self::expectException(\LogicException::class);
-        self::expectExceptionCode(1644403794);
-
-        $envelope = new Envelope(new class {});
-
-        $serializer = self::createMock(SerializerInterface::class);
-        $serializer->expects(self::once())
-            ->method('encode')
-            ->with($envelope)
-            ->willReturn([]);
-
-        $transport = new AzureTransport(
-            $serializer,
+            self::createStub(SerializerInterface::class),
             new MockHttpClient(),
             new MockHttpClient(),
             AzureTransport::RECEIVE_MODE_RECEIVE_AND_DELETE,

--- a/tests/Messenger/Transport/DsnParserTest.php
+++ b/tests/Messenger/Transport/DsnParserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\AymDev\MessengerAzureBundle\Messenger\Transport;
 
 use AymDev\MessengerAzureBundle\Messenger\Transport\DsnParser;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class DsnParserTest extends TestCase
@@ -44,10 +45,10 @@ class DsnParserTest extends TestCase
     }
 
     /**
-     * @dataProvider provideValidConfigurations
      * @param mixed[] $options
      * @param mixed[] $expectedResult
      */
+    #[DataProvider('provideValidConfigurations')]
     public function testParseValidDsn(string $dsn, array $options, array $expectedResult): void
     {
         $parser = new DsnParser();
@@ -79,7 +80,7 @@ class DsnParserTest extends TestCase
     /**
      * @return iterable<string, array{dsn: string, options: mixed[], expected: mixed[]}>
      */
-    public function provideMergingOrderTestData(): iterable
+    public static function provideMergingOrderTestData(): iterable
     {
         yield 'dsn options' => [
             'dsn' => 'azure://key-name:key-value@namespace-name?entity_path=entity-path&token_expiry=7200',
@@ -121,16 +122,16 @@ class DsnParserTest extends TestCase
     }
 
     /**
-     * @dataProvider provideMergingOrderTestData
      * @param mixed[] $options
-     * @param mixed[] $expectedResult
+     * @param mixed[] $expected
      */
-    public function testOptionsMergingOrder(string $dsn, array $options, array $expectedResult): void
+    #[DataProvider('provideMergingOrderTestData')]
+    public function testOptionsMergingOrder(string $dsn, array $options, array $expected): void
     {
         $parser = new DsnParser();
         $result = $parser->parseDsn($dsn, $options, 'my-transport');
 
-        self::assertSame($expectedResult, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -284,20 +285,20 @@ class DsnParserTest extends TestCase
     }
 
     /**
-     * @dataProvider provideInvalidConfigurations
      * @param mixed[] $options
      */
+    #[DataProvider('provideInvalidConfigurations')]
     public function testInvalidConfigThrowsException(
         string $dsn,
         array $options,
-        string $expectedError,
-        int $expectedCode = 0
+        string $error,
+        int $code = 0
     ): void {
         $parser = new DsnParser();
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedError);
-        $this->expectExceptionCode($expectedCode);
+        $this->expectExceptionMessage($error);
+        $this->expectExceptionCode($code);
 
         $parser->parseDsn($dsn, $options, 'my-transport');
     }


### PR DESCRIPTION
Updates Symfony version to allow v8.
Replaces the PHPUnit bridge with plain PHPUnit dependency, updates it to v13 and fixes tests.
Updates workflows to test on latests PHP & Symfony versions. Update PHPStan with its extensions to v2 and fix errors: also removes a check + test guaranteed by an interface.